### PR TITLE
Don’t overwrite document’s existing onload

### DIFF
--- a/timeline.js
+++ b/timeline.js
@@ -1,5 +1,5 @@
 // Run when document has loaded
-document.body.onload = Init();
+(document.readyState == 'complete' || document.readyState == 'interactive') ? Init() : document.addEventListener('DOMContentLoaded', Init);
 
 // Code to run when the document has loaded
 function Init() {


### PR DESCRIPTION
* Don’t overwrite document.body.onload – may break document.
* Document may already have finished loading, run now.
* Otherwise run when document says it’s ready.